### PR TITLE
Fix bug where a deck's reported status as shuffled was wrong.

### DIFF
--- a/deck/views.py
+++ b/deck/views.py
@@ -35,9 +35,9 @@ def new_deck(request, key='', shuffle=False):
         shuffled = True
     deck.save() #save the deck_count.
     if shuffled:
-        resp = {'success':True, 'deck_id':deck.key, 'remaining':len(deck.stack), 'shuffled':False}
-    else:
         resp = {'success':True, 'deck_id':deck.key, 'remaining':len(deck.stack)}
+    else:
+        resp = {'success':True, 'deck_id':deck.key, 'remaining':len(deck.stack), 'shuffled':False}
     return HttpResponse(json.dumps(resp), content_type="application/json")
 
 def draw(request, key):
@@ -74,7 +74,7 @@ def draw(request, key):
         success = False
     cards = deck.stack[0:card_count]
     deck.stack = deck.stack[card_count:]
-    deck.save() 
+    deck.save()
 
     a = []
     for card in cards:


### PR DESCRIPTION
There was a bug which made all decks have their shuffled status the opposite of what it should be. This was a pretty easy fix, so I fixed it.