### PR TITLE
Fix for Issue #26 - Partial deck reshuffle creates a new 52 card deck

### DIFF
--- a/deck/migrations/0003_deck_deck_contents.py
+++ b/deck/migrations/0003_deck_deck_contents.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import jsonfield.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('deck', '0002_deck_piles'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='deck',
+            name='deck_contents',
+            field=jsonfield.fields.JSONField(null=True, blank=True),
+        ),
+    ]

--- a/deck/models.py
+++ b/deck/models.py
@@ -26,16 +26,21 @@ class Deck(models.Model):
     deck_count = models.IntegerField(default=1)
     stack = JSONField(null=True, blank=True)
     piles = JSONField(null=True, blank=True)
+    deck_contents = JSONField(null=True, blank=True)
 
     def open_new(self, cards_used=None):
         stack = []
         if cards_used is None:
-            cards = CARDS
+            if self.deck_contents is None:
+                cards = CARDS
+            else:
+                cards = self.deck_contents[:]
         else:
             # Ignore case
             cards_used = cards_used.upper()
             # Only allow real cards
             cards = [x for x in CARDS if x in cards_used.split(',')]
+            self.deck_contents = cards[:]
 
         for i in range(0,self.deck_count):
             stack = stack+cards[:] #adding the [:] forces the array to be copied.

--- a/deck/tests.py
+++ b/deck/tests.py
@@ -85,6 +85,7 @@ class DeckTest(TestCase):
         self.assertEqual(piles['chase']['remaining'], 0)
 
     def test_partial_deck(self):
+        #test to make sure a new partial deck is returned when requested
         request = self.request_factory.get("/", {'cards':'AC,AD,AH,AS'})
         response = shuffle(request)
         self.assertEqual(response.status_code, 200)
@@ -94,6 +95,7 @@ class DeckTest(TestCase):
         deck_id = resp['deck_id']
         self.assertEqual(resp['remaining'], 4)
 
+        #draw 4 cards and make sure they match the input data (and verify deck is empty)
         request = self.request_factory.get("/", {'count':4})
         response = draw(request, deck_id)
         self.assertEqual(response.status_code, 200)
@@ -114,6 +116,17 @@ class DeckTest(TestCase):
         self.assertEqual(two, True)
         self.assertEqual(three, True)
         self.assertEqual(four, True)
+
+        #verify that reshuffling a partial deck returns a partial deck
+        request = self.request_factory.get("/", {'cards':'KC,KD,KH,KS'})
+        response = shuffle(request)
+        resp = json.loads(response.content.decode('utf-8'))
+        deck_id = resp['deck_id']
+        reshuffleRequest = self.request_factory.get("/", {})
+        response = shuffle(reshuffleRequest, deck_id)
+        resp = json.loads(response.content.decode('utf-8'))
+        self.assertEqual(resp['remaining'], 4)
+
     def test_draw_new(self):
         request = self.request_factory.get("/", {'count':5})
         response = draw(request)


### PR DESCRIPTION
This fix adds a ```deck_contents``` field which, if the deck was generated as a partial deck, will contain the original cards used in the deck. If the original deck was a full 52 card deck, then the ```deck_contents``` field is ```None``` (to prevent doubling the memory requirement for new full decks). 

The empty field behavior may want to be revisited if ```deck_contents``` is ever used for other purposes as it may be confusing in certain contexts.

This PR also includes a test-case for the partial deck reshuffling bug.