### PR TITLE
Various Joker code enhancements

### DIFF
--- a/deck/models.py
+++ b/deck/models.py
@@ -26,9 +26,9 @@ CARDS = ['AS', '2S', '3S', '4S', '5S', '6S', '7S', '8S', '9S', '0S', 'JS', 'QS',
          'AD', '2D', '3D', '4D', '5D', '6D', '7D', '8D', '9D', '0D', 'JD', 'QD', 'KD',
          'AC', '2C', '3C', '4C', '5C', '6C', '7C', '8C', '9C', '0C', 'JC', 'QC', 'KC',
          'AH', '2H', '3H', '4H', '5H', '6H', '7H', '8H', '9H', '0H', 'JH', 'QH', 'KH']
-JOKERS = ["XX", "XX"]
+JOKERS = ["X1", "X2"]
 
-SUITS = {'S': 'SPADES', 'D': 'DIAMONDS', 'H': 'HEARTS', 'C': 'CLUBS', 'X': 'N/A'}
+SUITS = {'S': 'SPADES', 'D': 'DIAMONDS', 'H': 'HEARTS', 'C': 'CLUBS', '1': 'BLACK', '2': 'RED'}
 VALUES = {'A': 'ACE', 'J': 'JACK', 'Q': 'QUEEN', 'K': 'KING', '0': '10', 'X': 'JOKER'}
 
 class Deck(models.Model):
@@ -44,15 +44,14 @@ class Deck(models.Model):
         stack = []
         if cards_used is None: # use all the cards
             if self.deck_contents is None:
-                cards = CARDS
-                if jokers_enabled:
-                    cards += JOKERS
+                cards = (CARDS, CARDS + JOKERS)[jokers_enabled]
             else:
                 cards = self.deck_contents[:]
         else: # use a subset of a standard deck
             cards_used = cards_used.upper()
             # Only allow real cards
-            cards = [x for x in CARDS if x in cards_used.split(',')]
+            valid_cards = (CARDS, CARDS + JOKERS)[jokers_enabled]
+            cards = [x for x in valid_cards if x in cards_used.split(',')]
             self.deck_contents = cards[:]  # save the subset for future shuffles
 
         for i in range(0, self.deck_count):  # for loop over how many decks someone wants. Blackjack is usually 6.

--- a/deck/templates/docs.html
+++ b/deck/templates/docs.html
@@ -237,7 +237,7 @@ https://deckofcardsapi.com/api/deck/new/
 </pre>
 
 <p>Open a brand new deck of cards. <br>A-spades, 2-spades, 3-spades... followed by diamonds, clubs, then hearts.
-<p class="note"><span style="font-weight:300;">NEW </span>(Oct 2019): Add <var>jokers=1</var> as a GET or POST parameter to your request to include two Jokers in the deck. (I understand that <var>jokers=1</var> returning you <var>2</var> jokers may be a little confusing. A standard deck of cards has 2 jokers, and it's standard for <var>1</var> to be used as a <a href="https://en.wikipedia.org/wiki/Truth_value">truthy boolean value</a> and <var>0</var> for a falsey value. You can always use <var>jokers=2</var> as a truthy value.)</p>
+<p class="note"><span style="font-weight:300;">NEW </span>(Oct 2019): Add <var>jokers_enabled=true</var> as a GET or POST parameter to your request to include two Jokers in the deck.</p>
 
 <h3>Response:</h3>
 <pre>

--- a/deck/views.py
+++ b/deck/views.py
@@ -13,8 +13,8 @@ def _get_request_var(request, key, default=1):
         return request.GET.get(key, default)
 
 def get_jokers_enabled(request):
-    j = _get_request_var(request, 'jokers', '0')
-    return bool(int(j))
+    j = _get_request_var(request, 'jokers_enabled', 'false')
+    return j=='true'
 
 def shuffle(request, key=''):
     print("shuffle")
@@ -131,9 +131,7 @@ def add_to_pile(request, key, pile):
     cards_specified = cards_specified.upper()
     # Only allow real cards
 
-    all_cards = CARDS
-    if jokers_enabled:
-        all_cards += JOKERS
+    all_cards = (CARDS, CARDS + JOKERS)[jokers_enabled]
     cards_specified = [x for x in cards_specified.split(',') if x not in deck.stack and x in all_cards]  # check that the cards has been drawn and is a valid card code.
 
     if not deck.piles:


### PR DESCRIPTION
Hi,

This PR enhances the Joker functionality, and also resolves an issue on the **live environment** where the deck is being flooded with Jokers for all users.

Changes include:
- Give Jokers unique ids to enable joker support for partial decks. Have tested this with the urls `http://127.0.0.1:8000/api/deck/new/shuffle/?jokers_enable=true&cards=AS,2S,3S,X1` and `http://127.0.0.1:8000/api/deck/new/shuffle/?cards=AS,2S,3S,X1. In the former url, a joker is returned, in the latter url, no joker is returned.
- Resolve issues caused CONSTANTS being modified (they were being passed by reference)
- Rename parameter required to enable joker support from `jokers=1` to `jokers_enabled=true` to make it more intuitive
- Update docs to reflect Joker parameter change

See the following comment for additional context:
https://github.com/crobertsbmw/deckofcards/pull/61#issuecomment-541913147

Please test this prior to merging. However, **the sooner this is merged the better as it resolves an issue which is currently on production.**

Thanks!