### PR TITLE
Addresses issue #104 - Shuffle remaining deck, draw random cards from piles and return cards to the deck

### DIFF
--- a/deck/urls.py
+++ b/deck/urls.py
@@ -22,4 +22,5 @@ urlpatterns = [
     url(r'^deck/(?P<key>\w+)/pile/(?P<pile>\w+)/shuffle/$', views.shuffle_pile, name='shuffle_pile'),
     url(r'^deck/(?P<key>\w+)/pile/(?P<pile>\w+)/draw/$', views.draw_from_pile, name='draw_pile'),
     url(r'^deck/(?P<key>\w+)/pile/(?P<pile>\w+)/draw/(?P<location>\w+)/$', views.draw_from_pile, name='draw_pile'),
+    url(r'^deck/(?P<key>\w+)/pile/(?P<pile>\w+)/return/$', views.return_pile_to_deck, name='return'),   
 ]


### PR DESCRIPTION
As per discussion on #104, this PR allows several things (documentation updates later)

- `/api/deck/<<deck id>>/shuffle/` now as an optional parameter `remaining=True` to only shuffle the remaining stack and leave any piles as they are
- `/api/deck/<<deck id>>/pile/<<pile id>>/draw/random/` will draw random cards from a pile (the `count` parameter can still be specified)
- `/api/deck/<<deck id>>/return/` or `/deck/<<deck id>>/return/cards=AS,2S` returns cards that have been drawn from piles or the deck back into the deck. Without specifying which cards to return it will return all cards that are not in piles or the deck already.