### PR TITLE
Force SSL redirection from HTTP to HTTPS

### DIFF
--- a/spades/settings.py
+++ b/spades/settings.py
@@ -69,6 +69,7 @@ ROOT_URLCONF = 'spades.urls'
 
 WSGI_APPLICATION = 'spades.wsgi.application'
 
+SECURE_SSL_REDIRECT = True
 
 # Database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases


### PR DESCRIPTION
Default is False

https://docs.djangoproject.com/en/3.2/ref/settings/#std:setting-SECURE_SSL_REDIRECT

Would fix #124 